### PR TITLE
Feature: Adding active_signal entity to identify the current signal

### DIFF
--- a/core/services/data_store.py
+++ b/core/services/data_store.py
@@ -49,3 +49,38 @@ class DataStore:
     #Retorna todas las señales almacenadas que sean instancias de SignalDataset.
     def get_signals(self):
         return {k: v for k, v in self._data.items() if isinstance(v, SignalDataset)}
+    
+
+    def set_active_signal(self, key: str):
+        """
+        Define la señal activa usando la clave de una señal almacenada.
+        Lanza ValueError si la clave no existe o no corresponde a una señal.
+        """
+        if key not in self._data:
+            raise ValueError(f"La señal con clave '{key}' no existe en el DataStore.")
+        if not isinstance(self._data[key], SignalDataset):
+            raise ValueError(f"El elemento '{key}' no es una señal válida (SignalDataset).")
+
+        self._data["active_signal"] = key
+
+
+    #Retornar la señal activa (instancia de SignalDataset). - Devuelve None si no hay una activa definida.
+    def get_active_signal(self):
+        key = self._data.get("active_signal")
+        if key and key in self._data:
+            return self._data[key]
+        return None
+
+    #Retornar la clave del signal activo (string) o None si no hay.
+    def get_active_signal_key(self):
+        return self._data.get("active_signal")
+
+    #Eliminar la referencia a la señal activa (no borra la señal del DataStore).
+    def clear_active_signal(self):
+        if "active_signal" in self._data:
+            del self._data["active_signal"]
+    
+    #Verificar si una clave corresponde a la señal activa
+
+    def is_active_signal(self, key: str):
+        return self._data.get("active_signal") == key

--- a/plugins/analysis/time/average/average_plugin.py
+++ b/plugins/analysis/time/average/average_plugin.py
@@ -21,6 +21,7 @@ class Average_plugin(IPlugin):
 
     def process(self, data: any):
         print(f"Average recibió datos: {data}")
+        self._load_dataset_from_store()
         if self.mainwin:
             # ejemplo: mostrar mensaje en statusBar (si existe)
             try:
@@ -54,7 +55,7 @@ class Average_plugin(IPlugin):
     
 
     def _load_dataset_from_store(self):
-        """Busca 'trials_dataset' en el DataStore y extrae time y matrix."""
+        """Carga el SignalDataset activo desde el DataStore y muestra sus TrialDataset asociados."""
         if not self.mainwin:
             return
 
@@ -62,21 +63,30 @@ class Average_plugin(IPlugin):
         if store is None:
             print("[Average] No hay servicio de DataStore.")
             return
+
+        # Obtener la señal activa
+        active_signal = store.get_active_signal()
+        if not active_signal:
+            print("[Average] No hay señal activa registrada en el DataStore.")
+            return
         
-        # Intentar obtener el SignalDataset principal
-        signal_ds: SignalDataset | None = store.get("raw", None)
-        if signal_ds is None:
-            print("No se encontró 'raw' (SignalDataset) en el DataStore.")
+        print(f"[Average] Señal activa: '{active_signal}'")
+        print(f"Formato: {active_signal.format}")
+        print(f"Archivo fuente: {active_signal.source_path}")
+        print(f"Sampling rate: {active_signal.sampling_rate} Hz")
+        print(f"Canales: {len(active_signal.channel_names)} → {active_signal.channel_names}")
+        print(f"Unidades: {active_signal.units}")
+        print(f"Dimensiones de signals: {active_signal.signals.shape}\n")
+
+        # Revisar si tiene trials asociados
+        if not hasattr(active_signal, "trials_dataset") or not active_signal.trials_dataset:
+            print("[Average] El SignalDataset no tiene TrialDataset asociados.")
             return
 
-        if not signal_ds.trials_dataset:
-            print("El SignalDataset no tiene trials asociados.")
-            return
+        print(f"Se encontraron {len(active_signal.trials_dataset)} TrialDataset asociados.\n")
 
-        print(f"Se encontraron {len(signal_ds.trials_dataset)} TrialDataset asociados.\n")
-
-        # Recorrer y mostrar información de cada trial
-        for i, td in enumerate(signal_ds.trials_dataset, start=1):
+        # Recorrer y mostrar información detallada de cada trial
+        for i, td in enumerate(active_signal.trials_dataset, start=1):
             print(f"── TrialDataset #{i} ──")
             print(f"Canal: {td.channel_name} (índice {td.channel_index})")
             print(f"Archivo origen: {td.source}")
@@ -84,4 +94,5 @@ class Average_plugin(IPlugin):
             print(f"Trials shape: {td.trials.shape}")
             print(f"Time_rel shape: {td.time_rel.shape}")
             print(f"Onsets: {len(td.onsets_s)} eventos\n")
+
 

--- a/plugins/preprocessing/trials/trials_plugin.py
+++ b/plugins/preprocessing/trials/trials_plugin.py
@@ -184,6 +184,13 @@ class TrialsPlugin(IPlugin):
                 QMessageBox.warning(self.widget, "Error", f"No se encontró la señal '{selected_key}'.")
                 self.mainwin.statusBar().showMessage("No hay señal cargada ('raw')", 4000)
             return None
+        
+        # Registrar la señal como la activa en el DataStore
+        try:
+            store.set_active_signal(selected_key)
+            print(f"[TrialsPlugin] Señal activa establecida: '{selected_key}'")
+        except ValueError as e:
+            print(f"[TrialsPlugin] No se pudo establecer la señal activa: {e}")
 
         ch   = int(self.ui.channelSpinBox.value())
         th   = float(self.ui.thresholdDoubleSpinBox.value())


### PR DESCRIPTION
se agregaron varios métodos que soportan identificar la señal activa en el espacio de trabajo. para acceder a la señal activa desde un plugin se puede usar:


    store = self.mainwin.kernel.get_service("DataStore")
            if store is None:
                print("[Average] No hay servicio de DataStore.")
                return

### Obtener la señal activa

    active_signal = store.get_active_signal()
    if not active_signal:
        print("[Average] No hay señal activa registrada en el DataStore.")
        return
