### PR TITLE
29 feature select active trials

### DIFF
--- a/app/view/main_window.py
+++ b/app/view/main_window.py
@@ -209,7 +209,7 @@ class MainWindow(QMainWindow):
             self.show_plugin_widget(plugin)
             if hasattr(plugin, "process"):
                 try:
-                    plugin.process("Hola desde MainWindow")
+                    plugin.process("Ventana abierta")
                 except Exception as e:
                     print("Error en process del plugin:", e)
         else:

--- a/core/services/signal_dataset.py
+++ b/core/services/signal_dataset.py
@@ -32,13 +32,10 @@ class SignalDataset:
             raise ValueError("trial debe ser de tipo TrialDataset")
         self.trials_dataset.append(trial)
 
-def get_active_trials(self) -> List["TrialDataset"]:
-    """
-    Retorna los TrialDataset activos (no descartados), con búsqueda O(n).
-    """
-    discarded = set(self.discarded_trials)
-    return [
-        trial
-        for i, trial in enumerate(self.trials_dataset)
-        if i not in discarded
-    ]
+    def get_active_trials(self) -> List["TrialDataset"]:
+        """Retorna los trials activos (no descartados) en O(n)."""
+        return [
+            trial
+            for i, trial in enumerate(self.trials_dataset)
+            if i not in self.discarded_trials
+        ]

--- a/core/services/signal_dataset.py
+++ b/core/services/signal_dataset.py
@@ -24,8 +24,21 @@ class SignalDataset:
 
     trials_dataset:List[TrialDataset] = field(default_factory=list)
 
+    discarded_trials: set[int] = field(default_factory=set)
+
     #Agregar un trial_dataset a la lista de trials dataset
     def add_trial_dataset(self, trial: "TrialDataset"):
         if not isinstance(trial, TrialDataset):
             raise ValueError("trial debe ser de tipo TrialDataset")
-        self.trials_dataset.append(trial)               
+        self.trials_dataset.append(trial)
+
+def get_active_trials(self) -> List["TrialDataset"]:
+    """
+    Retorna los TrialDataset activos (no descartados), con búsqueda O(n).
+    """
+    discarded = set(self.discarded_trials)
+    return [
+        trial
+        for i, trial in enumerate(self.trials_dataset)
+        if i not in discarded
+    ]

--- a/plugins/analysis/time/average/average_plugin.py
+++ b/plugins/analysis/time/average/average_plugin.py
@@ -1,5 +1,6 @@
 from core.plugins.interfaces import IPlugin
 from core.plugins.meta import PluginMeta
+from core.services.data_store import DataStore
 from core.services.signal_dataset import SignalDataset
 from plugins.analysis.time.average.average_plugin_ui import Ui_Average
 from PyQt5.QtWidgets import QWidget, QVBoxLayout, QMessageBox
@@ -49,6 +50,7 @@ class Average_plugin(IPlugin):
             self.widget = QWidget(parent)
             self.ui = Ui_Average()
             self.ui.setupUi(self.widget)
+            self.ensure_vtk()
 
             # Crear el VTK interactor dentro del contenedor del .ui
             vtk_layout = QVBoxLayout(self.ui.VTK_render_Qwidget)
@@ -57,12 +59,6 @@ class Average_plugin(IPlugin):
             self.vtk_widget = QVTKRenderWindowInteractor(self.ui.VTK_render_Qwidget)
             vtk_layout.addWidget(self.vtk_widget)
 
-            self.renwin = self.vtk_widget.GetRenderWindow()
-            try:
-                self.vtk_widget.Initialize()
-            except Exception:
-                pass
-
             # Conectar botón “Calculate Average”
             self.ui.pushButton.clicked.connect(self._on_calculate_average)
 
@@ -70,29 +66,38 @@ class Average_plugin(IPlugin):
             self.widget.setParent(parent)
 
         return self.widget
+    
+    def _log(self, *args):
+        print("[Average]", *args)
+
+    def _get_active_signal(self) -> SignalDataset | None:
+        """Devuelve la señal activa"""
+        try:
+            store: DataStore | None = self.mainwin.kernel.get_service("DataStore")
+            if store is None:
+                QMessageBox.warning(self.widget, "Error", "No se encontró el DataStore.")
+                return
+            ds = store.get_active_signal() if store else None
+            if not ds:
+                print("[Average] No hay señal activa registrada en el DataStore.")
+                return
+
+            self._log("_get_active_signal:", "ok" if ds else "None")
+            return ds
+        except Exception as e:
+            self._log("_get_active_signal error:", e)
+            return None
 
     def _on_calculate_average(self):
         """Carga el SignalDataset activo desde el DataStore y muestra sus TrialDataset asociados."""
-        if not self.mainwin:
-            return
 
-        store = self.mainwin.kernel.get_service("DataStore")
-        if store is None:
-            QMessageBox.warning(self.widget, "Error", "No se encontró el DataStore.")
-            return
-
-        # Obtener la señal activa
-        active_signal = store.get_active_signal()
-        if not active_signal:
-            print("[Average] No hay señal activa registrada en el DataStore.")
-            return
-        
-        if not active_signal.trials_dataset:
-            print("[Average] Esta señal no tiene TrialDataset asociado.")
-            return
+        active_signal = self._get_active_signal()        
+        # if not active_signal.trials_dataset:
+        #     print("[Average] Esta señal no tiene TrialDataset asociado.")
+        #     return
     
         #Tomar el trial # 0 para prácticidad
-        td = active_signal.trials_dataset[0]
+        td = active_signal.get_active_trials()[0]
 
         #calcular el promedio por muestras
         av_data = np.mean(td.trials, axis=1)
@@ -103,40 +108,101 @@ class Average_plugin(IPlugin):
         # Render en VTK
         self.render_average(t, av_data, td.channel_name, td.unit)
 
-    def render_average(self, t, av_data, channel_name, unit):
-        self.renwin.GetRenderers().RemoveAllItems()
+    def render_average(self, t, av_data, channel_name=None, unit=None):
+        """
+        Renderiza el promedio usando vtkContextView + vtkChartXY (similar a ERP).
+        t: array 1D de tiempos
+        av_data: array 1D de valores promedio
+        """
+        if self.view is None:
+            self.ensure_vtk()
 
-        # Crear tabla VTK
+        # Validaciones mínimas
+        t = np.asarray(t, dtype=float)
+        av = np.asarray(av_data, dtype=float)
+        if t.ndim != 1 or av.ndim != 1 or t.size != av.size:
+            QMessageBox.warning(self.widget, "Render error", "Vectores de tiempo y señal deben tener la misma longitud 1D.")
+            return
+
+        # Downsample si hay muchísimos puntos (para mantener interacción fluida)
+        MAX_SAMPLES = 2000
+        N = t.size
+        if N > MAX_SAMPLES:
+            factor = int(np.ceil(N / MAX_SAMPLES))
+            t_plot = t[::factor]
+            av_plot = av[::factor]
+        else:
+            t_plot = t
+            av_plot = av
+
+        # Limpiar escena y crear tabla VTK
+        scene = self.view.GetScene()
+        scene.ClearItems()
+
         table = vtk.vtkTable()
-        arr_time = vtk.vtkFloatArray()
-        arr_time.SetName("Time (s)")
-        arr_signal = vtk.vtkFloatArray()
-        arr_signal.SetName(f"{channel_name} [{unit}]")
+        arr_time = vtk.vtkFloatArray(); arr_time.SetName("Time (s)")
+        arr_sig  = vtk.vtkFloatArray();  arr_sig.SetName(f"{channel_name or 'Signal'} [{unit or ''}]")
 
-        for ti, si in zip(t, av_data):
+        for ti, si in zip(t_plot, av_plot):
             arr_time.InsertNextValue(float(ti))
-            arr_signal.InsertNextValue(float(si))
+            arr_sig.InsertNextValue(float(si))
 
         table.AddColumn(arr_time)
-        table.AddColumn(arr_signal)
+        table.AddColumn(arr_sig)
 
-        # Crear gráfico
-        renderer = vtk.vtkRenderer()
-        renderer.SetBackground(1, 1, 1)
-        self.renwin.AddRenderer(renderer)
-
+        # Chart + actor (igual patrón que ERP)
         chart = vtk.vtkChartXY()
-        scene = vtk.vtkContextScene()
-        actor = vtk.vtkContextActor()
         scene.AddItem(chart)
-        actor.SetScene(scene)
-        renderer.AddActor(actor)
-        scene.SetRenderer(renderer)
 
-        chart.SetTitle(f"Average - {channel_name}")
+        # Dibujar línea
         plot = chart.AddPlot(vtk.vtkChart.LINE)
         plot.SetInputData(table, 0, 1)
-        plot.SetColor(0, 0, 0, 255)
-        plot.SetWidth(1.5)
+        # Opcionales: ancho y color
+        try:
+            plot.SetWidth(1.5)
+            # SetColor espera RGBA (0..255) en algunas versiones
+            plot.SetColor(0, 0, 0, 255)
+        except Exception:
+            pass
 
-        self.renwin.Render()
+        chart.GetAxis(vtk.vtkAxis.BOTTOM).SetTitle("Time (s)")
+        chart.GetAxis(vtk.vtkAxis.LEFT).SetTitle(unit or "Amplitude")
+        chart.SetTitle(f"Average - {channel_name or ''}")
+
+        # Forzar render
+        try:
+            self.view.GetRenderWindow().Render()
+        except Exception:
+            # Fallback: si view no tiene RenderWindow usar vtk_widget
+            try:
+                self.vtk_widget.GetRenderWindow().Render()
+            except Exception:
+                pass
+
+
+    def ensure_vtk(self):
+        """Crea e inicializa los widgets VTK y las vistas (context view)."""
+        # Crear QVTK dentro del contenedor ya definido en el .ui
+        if not self.vtk_widget:
+            self.vtk_widget = QVTKRenderWindowInteractor(self.ui.VTK_render_Qwidget)
+            layout = self.ui.VTK_render_Qwidget.layout()
+            if layout is None:
+                layout = QVBoxLayout(self.ui.VTK_render_Qwidget)
+                layout.setContentsMargins(0, 0, 0, 0)
+                self.ui.VTK_render_Qwidget.setLayout(layout)
+            layout.addWidget(self.vtk_widget)
+
+        # ContextView (facilita charting similar a Erp_plugin)
+        self.view = vtk.vtkContextView()
+        self.view.SetRenderWindow(self.vtk_widget.GetRenderWindow())
+        # Fondo similar a ERP
+        try:
+            self.view.GetRenderer().SetBackground(0.98, 0.98, 0.98)
+        except Exception:
+            pass
+
+        # Inicializar interactores (evita errores en algunos SO)
+        try:
+            self.vtk_widget.Initialize()
+        except Exception:
+            pass

--- a/plugins/preprocessing/trials/trial_plugin_ui.py
+++ b/plugins/preprocessing/trials/trial_plugin_ui.py
@@ -178,6 +178,45 @@ class Ui_Trials(QtWidgets.QWidget):
 
         self.vbox.addLayout(self.formTime)
 
+        # ===== Subtítulo: Trials =====
+        self.lblTrialsTitle = QtWidgets.QLabel(self.panel)
+        self.lblTrialsTitle.setFont(_f_sub)
+        self.lblTrialsTitle.setText("Trials")
+        self.vbox.addWidget(self.lblTrialsTitle)
+
+        self.sep5 = QtWidgets.QFrame(self.panel)
+        self.sep5.setFrameShape(QtWidgets.QFrame.HLine)
+        self.sep5.setFrameShadow(QtWidgets.QFrame.Plain)
+        self.vbox.addWidget(self.sep5)
+
+        #==== Botones de navegación de trials ====
+        self.trialNavLayout = QtWidgets.QHBoxLayout()
+
+        self.Btn_prev_trial = QtWidgets.QPushButton(self.panel)
+        self.Btn_prev_trial.setText("Anterior")
+        self.Btn_prev_trial.setMinimumHeight(32)
+        self.trialNavLayout.addWidget(self.Btn_prev_trial)
+
+        self.Btn_next_trial = QtWidgets.QPushButton(self.panel)
+        self.Btn_next_trial.setText("Siguiente")
+        self.Btn_next_trial.setMinimumHeight(32)
+        self.trialNavLayout.addWidget(self.Btn_next_trial)
+
+        self.Btn_discard_trial = QtWidgets.QPushButton(self.panel)
+        self.Btn_discard_trial.setText("Discard")
+        self.Btn_discard_trial.setMinimumHeight(32)
+        self.trialNavLayout.addWidget(self.Btn_discard_trial)
+
+        # Agregar el layout horizontal a la caja vertical principal
+        self.vbox.addLayout(self.trialNavLayout)
+
+        #label para numero de trial revisado
+        self.currentTrialLabel = QtWidgets.QLabel(self.panel)
+        self.currentTrialLabel.setText("Trial actual: -")
+        self.currentTrialLabel.setAlignment(QtCore.Qt.AlignCenter)
+        self.currentTrialLabel.setStyleSheet("font-weight: bold; padding: 4px;")
+        self.vbox.addWidget(self.currentTrialLabel)
+
         # ===== Spacer & Actions =====
         self.vbox.addStretch(1)
 

--- a/plugins/preprocessing/trials/trials_plugin.py
+++ b/plugins/preprocessing/trials/trials_plugin.py
@@ -57,8 +57,10 @@ class TrialsPlugin(IPlugin):
     def stop(self):
         self._log("stop")
 
-    def process(self):
-        self._log("process")
+    def process(self, data: any):
+        self._log(f"process{data}")
+        self._populate_channels_once()
+
     # -------------- UI ---------------------
     def get_widget(self, parent=None):
         if self.widget is None:
@@ -72,6 +74,9 @@ class TrialsPlugin(IPlugin):
 
             self._populate_channels_once()
 
+            #Botones para navegar entre trials
+            self.ui.Btn_prev_trial.clicked.connect(lambda: self.navigate_trial(-1))
+            self.ui.Btn_next_trial.clicked.connect(lambda: self.navigate_trial(1))
         else:
             self.widget.setParent(parent)
 
@@ -225,18 +230,118 @@ class TrialsPlugin(IPlugin):
 
         try:
             ds.add_trial_dataset(td)
+            ds.discarded_trials.clear()
         except Exception as e:
             self._log("add_trial_dataset warning:", e)
 
+        #Se muestra solo el primer trial
         self.last_td = td
-        T = td.trials.shape[1]
-        self.visible_trials = [1] if T > 0 else []
-        self._render_trials(td)
+        self.navigate_trial(0)
 
         if self.mainwin:
             self.mainwin.statusBar().showMessage(
                 f"Trials: T={td.trials.shape[1]}, Ns={td.trials.shape[0]}, canal='{td.channel_name}'",
                 4000
+            )
+
+    # -------------- Navegación entre trials ----------------------
+    def navigate_trial(self, direction: int):
+        """
+        Muestra el siguiente o anterior trial según 'direction'.
+        direction = +1 → siguiente
+        direction = -1 → anterior
+        """
+        if not self.last_td:
+            QMessageBox.information(self.widget, "Navegación", "No hay trials cargados.")
+            return
+
+        td = self.last_td
+        sd = self._get_active_signal()
+        
+        _, T = td.trials.shape
+        if T == 0:
+            QMessageBox.information(self.widget, "Navegación", "No hay trials disponibles.")
+            return
+
+        if not self.visible_trials:
+            self.visible_trials = [0]
+
+        current = self.visible_trials[0]
+        new_idx = (current + direction) % T  # navegación circular
+        self.visible_trials = [new_idx]
+
+        self._log(f"Navegando trial {new_idx + 1}/{T}")
+        self._render_trials(td)
+
+        # Actualizar el label del trial actual
+        if new_idx in sd.discarded_trials:
+            self.ui.currentTrialLabel.setText(f"Trial actual: {new_idx + 1} (descartado)/{T}")
+            self.ui.currentTrialLabel.setStyleSheet("color: red; font-weight: bold;")
+            self.ui.Btn_discard_trial.setText("Include")
+        else:
+            self.ui.currentTrialLabel.setText(f"Trial actual: {new_idx + 1}/{T}")
+            self.ui.currentTrialLabel.setStyleSheet("color: black; font-weight: bold;")
+            self.ui.Btn_discard_trial.setText("Discard")
+
+            # Conectar solo una vez
+            try:
+                self.ui.Btn_discard_trial.clicked.disconnect()
+            except Exception:
+                pass
+            self.ui.Btn_discard_trial.clicked.connect(lambda _, idx=new_idx: self._on_discard_trial(idx))
+
+
+        # Feedback en barra de estado
+        if self.mainwin:
+            self.mainwin.statusBar().showMessage(
+                f"Trial {new_idx + 1} de {T}", 2000
+            )
+
+
+    def _on_discard_trial(self, index: int):
+
+        ds = self._get_active_signal()
+
+        """Alterna el estado de descarte del trial actual (añadir o remover de la lista del SignalDataset)."""
+        if not self.last_td:
+            QMessageBox.information(self.widget, "Descartar Trial", "No hay trials cargados.")
+            return
+        
+        if not ds:
+            QMessageBox.warning(self.widget, "Descartar Trial", "No se encontró la señal activa.")
+            return
+      
+        if not self.visible_trials:
+            QMessageBox.information(self.widget, "Descartar Trial", "No hay trial seleccionado.")
+            return
+
+        # current = self.visible_trials[0]
+
+
+        # Alternar descarte / inclusión
+        if index in ds.discarded_trials:
+            # ➕ Incluir nuevamente
+            ds.discarded_trials.discard(index)
+            self._log(f"Trial {index + 1} incluido nuevamente.")
+            self.ui.currentTrialLabel.setText(f"Trial actual: {index + 1}")
+            self.ui.currentTrialLabel.setStyleSheet("color: black; font-weight: bold;")
+            self.ui.Btn_discard_trial.setText("🗑️ Discard Trial")
+            QMessageBox.information(
+                self.widget,
+                "Trial incluido",
+                f"El trial {index + 1} ha sido incluido nuevamente."
+            )
+        else:
+            # 🚫 Marcar como descartado
+            ds.discarded_trials.add(index)
+            self._log(f"Trial {index + 1} marcado como descartado.")
+            self.ui.currentTrialLabel.setText(f"Trial actual: {index + 1} (descartado)")
+            self.ui.currentTrialLabel.setStyleSheet("color: red; font-weight: bold;")
+            self.ui.Btn_discard_trial.setText("Include")
+            QMessageBox.information(
+                self.widget,
+                "Trial descartado",
+                f"El trial {index + 1} ha sido descartado y no se tendrá en cuenta."
             )
 
     # -------------- Render ----------------------


### PR DESCRIPTION
Se agregó la funcionalidad en trials_plugin para recorrer individualmente y elegir cuales se descargan de los futuros analisis, y se implementó el metodo get_active_trials en signal_dataset, para obtener solo aquellos trials activos, se usó un set, para definir los trials descartados y no aumentar la complejidad del código.

Se implementó get_active_trials en el plugin de average